### PR TITLE
Added more installation instructions for hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Please use the Google Form linked on the bottom of the page at https://postmerit
 
 ## Adding a translation
 * Fork the repo
-* Make sure that you have Hugo installed: `brew install hugo`
+* Make sure that you have Hugo installed:
+	* On macOS: `brew install hugo`
+	* On most Linux distros: `snap install hugo`
+	* See [here](https://gohugo.io/getting-started/installing/) for more options
+
 * Create an empty markdown file called `_index.<COUNTRY_CODE>.md` in the `content` directory
 * Write your translation there. Be sure to copy the structure of the English version at `index.md`, including all the special codes.
 * Add an entry to `config.toml` with your language information under the [Languages] tag. For example, for Swedish, you would enter:


### PR DESCRIPTION
@CoralineAda I have added a couple more details to the `hugo` installation line in the README. This should be useful for other folks like me who use Linux (or other OSes) and are unfamiliar with this tool.

(I came here to work on translation, but thought this might be a useful first addition. Hope it's alright!)