### PR TITLE
Add Portuguese translation

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -26,3 +26,7 @@ languageCode = "hi"
 [Languages.de]
 languageName = "Deutsch"
 languageCode = "de"
+
+[Languages.pt]
+languageName = "Português"
+languageCode = "pt"

--- a/content/_index.pt.md
+++ b/content/_index.pt.md
@@ -1,0 +1,47 @@
++++
+title = "O Manifesto da Pós-Meritocracia"
++++
+
+{{% section %}}
+
+## O Manifesto da Pós-Meritocracia
+
+{{< translations >}}
+
+A meritocracia é um princípio fundador do movimento de código aberto, e o ideal de meritocracia é perpetuado em todo o nosso campo na forma como as pessoas são recrutadas, contratadas, retidas, promovidas e valorizadas.
+
+No entanto, a meritocracia consistentemente mostrou-se beneficiar aqueles com privilégios, excluindo pessoas sub-representadas na tecnologia. A ideia de mérito nunca é claramente definida; ao contrário, parece ser uma forma de reconhecimento, um reconhecimento de que “essa pessoa é valiosa na medida em que é parecida comigo”.
+
+(Se você não estiver familiarizado com as críticas à meritocracia, consulte os recursos <a href="/meritocracy/">nesta página</a>.)
+
+É hora de nós, como indústria, abandonarmos a noção de que o mérito é algo que pode ser medido, e que pode ser almejado em igualdade de condições por todos os indivíduos, e que pode ser distribuído de forma justa.
+
+Como é um mundo pós-meritocracia? Está fundamentado em um conjunto central de valores e princípios, uma afirmação de pertencimento que se aplica a todos que se engajam na prática do desenvolvimento de software.
+
+### Nossos valores
+
+Estes valores e princípios fundamentais são:
+
+* Não acreditamos que nosso valor como seres humanos esteja intrinsecamente ligado ao nosso valor como trabalhadores do conhecimento. Nossas profissões não nos definem; Somos mais do que o trabalho que fazemos.
+* Acreditamos que as habilidades interpessoais são pelo menos tão importantes quanto as habilidades técnicas.
+* Podemos agregar mais valor como profissionais, aproveitando a diversidade de nossas identidades, origens, experiências e perspectivas. A homogeneidade é um antipadrão.
+* Podemos obter sucesso enquanto levamos vidas ricas e gratificantes. Nosso sucesso e valor não dependem de exercer toda a nossa energia em contribuir para o software.
+* Temos a obrigação de usar nossas posições de privilégio, por mais tênues que sejam, para melhorar a vida dos outros.
+* Devemos dar espaço para pessoas que não são como nós para entrar em nosso campo e ter sucesso nele. Isso significa não apenas convidá-los, mas garantir que eles sejam suportados e capacitados.
+* Temos a responsabilidade ética de nos recusarmos a trabalhar em software que tenha um impacto negativo no bem-estar de outras pessoas.
+* Reconhecemos o valor dos contribuidores não-técnicos como igual ao valor dos contribuidores técnicos.
+* Entendemos que trabalhar em nosso campo é um privilégio, não um direito. O impacto negativo de pessoas tóxicas no local de trabalho ou na comunidade em geral não é compensado por suas contribuições técnicas.
+* Estamos dedicados a praticar a compaixão e não o desprezo. Nós nos recusamos a menosprezar outras pessoas por causa de suas escolhas de ferramentas, técnicas ou linguagens.
+* O campo do desenvolvimento de software abrange mudanças técnicas, e é aprimorado aceitando também a mudança social.
+* Nós nos esforçamos para refletir nossos valores em tudo o que fazemos. Entendemos que valores que são adotados mas não praticados não são valores.
+
+### Signatários
+
+<p class="callout">
+  Para adicionar seu nome à lista de signatários, <a href="https://goo.gl/forms/9JT45K1iuKcBSPFj2"> assine este formulário </a>.
+</ p>
+
+{{<data-list "static/signatories.csv">}}
+
+{{% /section %}}
+G


### PR DESCRIPTION
There are be some Portuguese vs Brazilian Portuguese differences, but I wasn't sure they're significant enough to warrant a separate `_index.br.md`. Happy to split it, though!