### PR TITLE
Remove extraneous G from the bottom of the PT translation

### DIFF
--- a/content/_index.pt.md
+++ b/content/_index.pt.md
@@ -44,4 +44,3 @@ Estes valores e princípios fundamentais são:
 {{<data-list "static/signatories.csv">}}
 
 {{% /section %}}
-G


### PR DESCRIPTION
Yet another tiny fix, this time for:

![image](https://user-images.githubusercontent.com/81859/40678503-1857885e-6357-11e8-91a8-582a623bdcd4.png)
