### PR TITLE
Fix French language name

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ languageCode = "en"
 weight = 1
 
 [Languages.fr]
-languageName = "French"
+languageName = "Français"
 languageCode = "fr"
 
 [Languages.sp]


### PR DESCRIPTION
I noticed all languages names were translated except for French. Here is a fix :)