### PR TITLE
Fix webpage for Spanish

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,9 +23,9 @@ weight = 1
 languageName = "Français"
 languageCode = "fr"
 
-[Languages.sp]
+[Languages.es]
 languageName = "Español"
-languageCode = "sp"
+languageCode = "es"
 
 [Languages.hi]
 languageName = "हिन्दी भाषा"


### PR DESCRIPTION
Use `es` instead of `spa`, according to ISO 639-1