### PR TITLE
Revert "Fix wikipedia link"

### DIFF
--- a/content/meritocracy/_index.md
+++ b/content/meritocracy/_index.md
@@ -10,7 +10,7 @@ There are a number of resources for understanding the shortcomings of meritocrac
 
 <ul>
   <li>
-    <a href="https://en.wikipedia.org/wiki/Meritocracy#Critique">
+    <a href="https://en.wikipedia.org/wiki/Meritocracy#Criticism">
       Meritocracy (Criticism)
     </a>
   </li>

--- a/public/meritocracy/index.html
+++ b/public/meritocracy/index.html
@@ -388,7 +388,7 @@ a:hover {
 
 <ul>
   <li>
-    <a href="https://en.wikipedia.org/wiki/Meritocracy#Critique">
+    <a href="https://en.wikipedia.org/wiki/Meritocracy#Criticism">
       Meritocracy (Criticism)
     </a>
   </li>


### PR DESCRIPTION
This reverts commit 45ad1fc5cbbccfca6fd1c4c12b1bc6511cd45930.

Wikipedia section names will change from time to time, but 'Criticism' is a fairly commonly used section name, so other variants will usually be converted back to 'Criticism'.